### PR TITLE
'null' is the required way to indicate no layout.

### DIFF
--- a/website/atom.xml.erb
+++ b/website/atom.xml.erb
@@ -2,7 +2,7 @@
 title: example.com
 feed_url: http://example.com/atom.xml
 rss_length: 15
-layout: nil
+layout: null
 ...
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">

--- a/website/sitemap.xml.erb
+++ b/website/sitemap.xml.erb
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 ...
 <?xml version='1.0' encoding='UTF-8'?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
The default nil-layout specification doesn't work, and causes an error on site generation.

Following the instructions here: http://www.zenspider.com/projects/zenweb.html http://www.zenspider.com/projects/zenweb.html#creating-a-new-site results in the following (truncated) error:

```
#<RuntimeError: unknown layout "nil" for page "atom.xml.erb">
/home/srbaker/Projects/tmp/zenweb-template-1.0.2/website/.isolate/ruby-2.3.0/gems/zenweb-3.10.1/lib/zenweb/site.rb:122:in `layout'
/home/srbaker/Projects/tmp/zenweb-template-1.0.2/website/.isolate/ruby-2.3.0/gems/zenweb-3.10.1/lib/zenweb/page.rb:310:in `layout'
/home/srbaker/Projects/tmp/zenweb-template-1.0.2/website/.isolate/ruby-2.3.0/gems/zenweb-3.10.1/lib/zenweb/page.rb:471:in `wire'
/home/srbaker/Projects/tmp/zenweb-template-1.0.2/website/.isolate/ruby-2.3.0/gems/zenweb-3.10.1/lib/zenweb/site.rb:272:in `block in wire'
/home/srbaker/Projects/tmp/zenweb-template-1.0.2/website/.isolate/ruby-2.3.0/gems/zenweb-3.10.1/lib/zenweb/site.rb:271:in `each'
/home/srbaker/Projects/tmp/zenweb-template-1.0.2/website/.isolate/ruby-2.3.0/gems/zenweb-3.10.1/lib/zenweb/site.rb:271:in `wire'
/home/srbaker/Projects/tmp/zenweb-template-1.0.2/website/.isolate/ruby-2.3.0/gems/zenweb-3.10.1/lib/zenweb/tasks.rake:9:in `website'
/home/srbaker/Projects/tmp/zenweb-template-1.0.2/website/.isolate/ruby-2.3.0/gems/zenweb-3.10.1/lib/zenweb/tasks.rake:19:in `block in <top (required)>'

...
```

Changing the layout to `null` in both places fixes this.